### PR TITLE
Add reverse proxy for backend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,6 @@ services:
       MYSQL_PASSWORD: root
     volumes:
       - liferay-grow-db:/var/lib/mysql
-    ports:
-      - "3306:3306"
     restart: 'always'
   api:
     build: ./packages/backend
@@ -35,15 +33,11 @@ services:
       TYPEORM_MIGRATIONS: dist/src/migration/*.js
       AUTH_MIDDLEWARE_ENABLED: "true"
       VALIDATE_LIFERAY_ORG: "true"
-    ports: 
-      - '3333:3333'
     depends_on: 
       - mysql
   web:
     build: ./packages/frontend
     container_name: liferay-grow-frontend
-    ports:
-      - '3000:3000'
     depends_on: 
       - api
       - mysql
@@ -59,5 +53,9 @@ services:
     ports:
       - "80:80"
       - "443:443"
+    depends_on: 
+      - api
+      - mysql
+      - web
 volumes: 
   liferay-grow-db:

--- a/nginx/config/conf.d/prod/nginx.conf
+++ b/nginx/config/conf.d/prod/nginx.conf
@@ -1,4 +1,10 @@
 server {
+    listen 80;
+    server_name localhost;
+    return 301 https://$host$request_uri;
+}
+
+server {
     listen 443 ssl default_server;
     server_name localhost;
     
@@ -21,6 +27,20 @@ server {
 
     location / {
         proxy_pass       http://web:3000;
+        proxy_http_version 1.1;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Server $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Host $http_host;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_pass_request_headers on;
+    }
+
+    location /graphql {
+        proxy_pass       http://api:3333/;
         proxy_http_version 1.1;
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Server $host;


### PR DESCRIPTION
This PR adds reverse proxy for the API backend server and protect the other services by hiding their ports.